### PR TITLE
start with dependencies to enjoy caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:latest
-ADD . /code
 WORKDIR /code
-RUN npm install
+
+# start with dependencies to enjoy caching
+COPY ./package.json /code/package.json
+COPY ./package-lock.json /code/package-lock.json
+RUN npm ci
+
+# copy rest and build
+COPY . /code/.
 CMD ["node", "index.js"]


### PR DESCRIPTION
The quick-boot trick used in [example-vite](https://github.com/letsdiscodev/example-vite/blob/main/Dockerfile) makes sense here too.

Two comments:
 - This uses `npm ci` instead of `npm install`, which seems like better practice. If that makes sense I'll make a PR patching that backwards into example-vite
 - To me it makes sense to generally use `node:lts` instead of `node:latest` as the base image, but I don't have strong enough feelings about it to start off with that change